### PR TITLE
refactor: rename UserManager to UserService (internal only)

### DIFF
--- a/src/user_manager.py
+++ b/src/user_manager.py
@@ -1,4 +1,4 @@
-class UserManager:
+class UserService:
     def authenticate(self, user_id: str) -> bool:
         return True
 


### PR DESCRIPTION
Internal rename only — UserService is not a public API surface. No doc update required.