### PR TITLE
refactor(payments): rename init_payment→create_payment, partial refund support

### DIFF
--- a/src/payments.py
+++ b/src/payments.py
@@ -1,11 +1,11 @@
-def init_payment(amount: float, currency: str = "USD") -> dict:
-    """Initiate a payment transaction."""
-    return {"transaction_id": "txn_123", "status": "pending", "currency": currency}
+def create_payment(amount: float, currency: str = "USD", customer_id: str | None = None) -> dict:
+    """Create a new payment transaction."""
+    return {"transaction_id": "txn_123", "status": "pending", "currency": currency, "customer_id": customer_id}
 
 
-def refund_payment(transaction_id: str, reason: str = "") -> dict:
-    """Refund a previously initiated payment."""
-    return {"transaction_id": transaction_id, "status": "refunded", "reason": reason}
+def refund_payment(transaction_id: str, amount: float | None = None) -> dict:
+    """Refund a previously initiated payment. Partial refunds supported via amount param."""
+    return {"transaction_id": transaction_id, "status": "refunded", "amount": amount}
 
 
 def handle_webhook(payload: dict, secret: str) -> dict:


### PR DESCRIPTION
Renames `init_payment` to `create_payment` with an added `customer_id` parameter.
Updates `refund_payment` to support partial refunds via optional `amount` param.

**Expected:** DocuGardener should detect drift against `docs/src/payments.md` which still references `init_payment` and the old `refund_payment` signature.