### PR TITLE
feat(payments): add capture and dispute payment functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ DocuGardener beta test repo
 # test Tue Apr 21 18:15:59 CEST 2026
 # test Tue Apr 21 18:16:51 CEST 2026
 # test Tue Apr 21 18:22:03 CEST 2026
+# test Tue Apr 21 18:37:45 CEST 2026

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # docugardener-test
 DocuGardener beta test repo
+# test

--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ DocuGardener beta test repo
 # test Tue Apr 21 18:14:47 CEST 2026
 # test Tue Apr 21 18:15:59 CEST 2026
 # test Tue Apr 21 18:16:51 CEST 2026
+# test Tue Apr 21 18:22:03 CEST 2026

--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 DocuGardener beta test repo
 # test
 # test Tue Apr 21 18:14:47 CEST 2026
+# test Tue Apr 21 18:15:59 CEST 2026

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # docugardener-test
 DocuGardener beta test repo
 # test
+# test Tue Apr 21 18:14:47 CEST 2026

--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@ DocuGardener beta test repo
 # test
 # test Tue Apr 21 18:14:47 CEST 2026
 # test Tue Apr 21 18:15:59 CEST 2026
+# test Tue Apr 21 18:16:51 CEST 2026

--- a/src/payments.py
+++ b/src/payments.py
@@ -1541,3 +1541,66 @@ def calculate_fx_conversion_601c5a(
         "gross": gross, "fee": fee, "net": net,
     }
 
+
+
+def capture_payment(
+    transaction_id: str,
+    amount: float | None = None,
+    capture_method: str = "automatic",
+    statement_descriptor: str | None = None,
+) -> dict:
+    """Capture an authorized payment, optionally for a partial amount.
+
+    Moves a payment from 'authorized' state to 'captured'. If amount is
+    omitted the full authorized amount is captured. Only works on payments
+    with capture_method='manual' that are in 'authorized' state.
+
+    Args:
+        transaction_id: The payment to capture.
+        amount: Partial capture amount. Defaults to full authorized amount.
+        capture_method: 'automatic' or 'manual'. Defaults to 'automatic'.
+        statement_descriptor: Custom text shown on the customer's bank statement.
+
+    Returns:
+        dict with transaction_id, captured_amount, status, and statement_descriptor.
+    """
+    return {
+        "transaction_id": transaction_id,
+        "status": "captured",
+        "captured_amount": amount,
+        "capture_method": capture_method,
+        "statement_descriptor": statement_descriptor,
+    }
+
+
+def dispute_payment(
+    transaction_id: str,
+    reason: str,
+    evidence: dict | None = None,
+    submit_immediately: bool = False,
+) -> dict:
+    """Open or respond to a payment dispute (chargeback).
+
+    Submits dispute evidence to the payment processor. Evidence should
+    include customer communications, shipping proof, and service records.
+    Disputes not responded to within 7 days are automatically lost.
+
+    Args:
+        transaction_id: The disputed payment's transaction ID.
+        reason: Dispute reason code (e.g. 'fraudulent', 'product_not_received').
+        evidence: Dict of supporting documents. Keys: customer_communication,
+                  shipping_documentation, service_documentation.
+        submit_immediately: If True, submits evidence to processor right away.
+                            If False, saves as draft for review.
+
+    Returns:
+        dict with dispute_id, status ('draft' or 'submitted'), and deadline.
+    """
+    return {
+        "transaction_id": transaction_id,
+        "dispute_id": f"dp_{transaction_id[:8]}",
+        "reason": reason,
+        "status": "submitted" if submit_immediately else "draft",
+        "evidence_received": bool(evidence),
+        "deadline_days": 7,
+    }


### PR DESCRIPTION
## Summary

- Adds `capture_payment()` — captures authorized payments with optional partial amount and custom statement descriptor
- Adds `dispute_payment()` — opens/responds to chargebacks with evidence submission, 7-day deadline tracking

## Note

Documentation in `docs/src/payments.md` intentionally not updated — testing DocuGardener drift detection.