### PR TITLE
feat(payments): add dispute webhook handler

### DIFF
--- a/src/payments.py
+++ b/src/payments.py
@@ -1541,3 +1541,33 @@ def calculate_fx_conversion_601c5a(
         "gross": gross, "fee": fee, "net": net,
     }
 
+
+
+def handle_dispute_webhook(payload: dict, secret: str) -> dict:
+    """Process incoming dispute webhook events from the payment processor.
+
+    Handles dispute.created, dispute.updated, and dispute.closed events.
+    Updates internal dispute records and triggers customer notification
+    workflows where applicable.
+
+    Args:
+        payload: Raw webhook payload from payment processor.
+        secret: Webhook signing secret for HMAC verification.
+
+    Returns:
+        dict with event_type, dispute_id, status, and action_taken.
+    """
+    event_type = payload.get("type", "")
+    dispute_id = payload.get("data", {}).get("object", {}).get("id", "unknown")
+
+    if event_type == "dispute.created":
+        return {"event_type": event_type, "dispute_id": dispute_id,
+                "status": "open", "action_taken": "flagged_for_review"}
+    elif event_type == "dispute.updated":
+        return {"event_type": event_type, "dispute_id": dispute_id,
+                "status": "under_review", "action_taken": "evidence_submitted"}
+    elif event_type == "dispute.closed":
+        return {"event_type": event_type, "dispute_id": dispute_id,
+                "status": "closed", "action_taken": "resolved"}
+    return {"event_type": event_type, "dispute_id": dispute_id,
+            "status": "unknown", "action_taken": "logged"}

--- a/src/payments.py
+++ b/src/payments.py
@@ -1572,3 +1572,4 @@ def handle_dispute_webhook(payload: dict, secret: str) -> dict:
     return {"event_type": event_type, "dispute_id": dispute_id,
             "status": "unknown", "action_taken": "logged"}
 # test 1776783555
+# trigger 1776784172

--- a/src/payments.py
+++ b/src/payments.py
@@ -1571,3 +1571,4 @@ def handle_dispute_webhook(payload: dict, secret: str) -> dict:
                 "status": "closed", "action_taken": "resolved"}
     return {"event_type": event_type, "dispute_id": dispute_id,
             "status": "unknown", "action_taken": "logged"}
+# test 1776783555


### PR DESCRIPTION
Adds handle_dispute_webhook() without updating docs — testing DocuGardener drift detection